### PR TITLE
adjusting VSCode settings for PYTHONPATH

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,10 @@
+PYTHONPATH=./src
+# PLEASE be careful not to commit credential information
+# .env files are added into the .gitignore in order to avoid committing them
+SNOWSQL_ACCOUNT=<replace with your account identifer>
+SNOWSQL_USER=<replace with your username>
+SNOWSQL_ROLE=<replace with your role>
+SNOWSQL_PWD=<replace with your password>
+SNOWSQL_DATABASE=<replace with your database>
+SNOWSQL_SCHEMA=<replace with your schema>
+SNOWSQL_WAREHOUSE=<replace with your warehouse>

--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,4 @@ dmypy.json
 .DS_Store
 
 app.zip
+oryx-build-commands.txt

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,23 @@
+{
+    "terminal.integrated.env.osx": {
+        "PYTHONPATH": "${env:PYTHONPATH}:${workspaceFolder}/src",
+      },
+      "terminal.integrated.env.linux": {
+        "PYTHONPATH": "${env:PYTHONPATH}:${workspaceFolder}/src",
+      },
+      "terminal.integrated.env.windows": {
+        "PYTHONPATH": "${env:PYTHONPATH};${workspaceFolder}/src",
+      },
+      /* Env files are practical for storing settings.
+      For example to connect to the database or setting the PYTHONPATH
+      
+      */
+      "python.envFile": "${workspaceFolder}/.env",
+      "files.exclude": {
+        "**/.git": true,
+        "Lib": true,
+        "Include": true,
+        "Scripts": true,
+        "**/__pycache__":true
+    }   
+}

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ To develop your applications locally, you will need
 - Python 3.8 or greater
 - An IDE or code editor (VS Code, PyCharm, etc.)
 
+> NOTE: `PYTHONPATH` is an environment variable in Python that specifies a list of directories where Python should look for modules and packages when importing them. It is crucial when your source code is organized below the "src" folder, as setting `PYTHONPATH` to include the parent directory of "src" ensures that Python can locate and import your modules correctly, facilitating seamless collaboration and efficient module management within your project.
+
 ## Usage
 
 Once you've set your credentials and installed the packages, you can test your connection to Snowflake by executing the stored procedure in [`app.py`](src/procs/app.py):

--- a/resources.sql
+++ b/resources.sql
@@ -10,7 +10,7 @@ CREATE OR REPLACE PROCEDURE HELLO_WORLD_PROC()
     LANGUAGE PYTHON
     RUNTIME_VERSION = 3.8
     IMPORTS = ('@artifacts/&artifact_name')
-    HANDLER = 'src.app.run'
+    HANDLER = 'app.run'
     PACKAGES = ('pytest','snowflake-snowpark-python','tomli','toml');
 
 CREATE OR REPLACE FUNCTION COMBINE(a String, b String)
@@ -18,5 +18,5 @@ CREATE OR REPLACE FUNCTION COMBINE(a String, b String)
     LANGUAGE PYTHON
     RUNTIME_VERSION = 3.8
     IMPORTS = ('@artifacts/&artifact_name')
-    HANDLER = 'src.functions.combine'
+    HANDLER = 'functions.combine'
     PACKAGES = ('pytest','snowflake-snowpark-python','tomli','toml');

--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,16 @@ Run `conda env create --file environment.yaml` to create an editable
 install of this project
 """
 
-from setuptools import setup, find_packages
+from setuptools import setup
 
+PACKAGE_NAME="Example_Snowpark_Python_project"
 setup(
-    name="Example Snowpark Python project",
+    name=PACKAGE_NAME,
     version="0.1.0",
-    packages=find_packages()
+    # Specify the package directory
+    package_dir={'': 'src'},
+    # Include all files from the src directory
+    package_data={PACKAGE_NAME: ['*']}
 )
+
+# you can run python setup.py bdist_wheel

--- a/src/app.py
+++ b/src/app.py
@@ -6,7 +6,7 @@ and testing.
 from snowflake.snowpark.session import Session
 from snowflake.snowpark.dataframe import col, DataFrame
 from snowflake.snowpark.functions import udf
-from src import functions
+import functions
 
 def run(snowpark_session: Session) -> DataFrame:
     """
@@ -35,11 +35,11 @@ def run(snowpark_session: Session) -> DataFrame:
 if __name__ == "__main__":
     # This entrypoint is used for local development (`$ python src/procs/app.py`)
 
-    from src.util.local import get_env_var_config
+    from util.local import get_env_var_config
 
     print("Creating session...")
     session = Session.builder.configs(get_env_var_config()).create()
-    session.add_import(functions.__file__, 'src.functions')
+    session.add_import(functions.__file__, 'functions')
 
     print("Running stored procedure...")
     result = run(session)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,7 +4,7 @@ Fixtures and configurations for the PyTest suite
 
 import pytest
 from snowflake.snowpark.session import Session
-from src.util.local import get_env_var_config
+from util.local import get_env_var_config
 
 @pytest.fixture
 def session(scope='module'):

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -3,11 +3,11 @@ Tests for the procedure module.
 """
 
 from snowflake.snowpark.session import Session
-from src import functions
-from src.app import run
+import functions
+from app import run
 
 def test_app_dim(session: Session):
-    session.add_import(functions.__file__, 'src.functions')
+    session.add_import(functions.__file__, 'functions')
     expected = session.create_dataframe(
         [["Welcome to Snowflake!"], ["Learn more: https://www.snowflake.com/snowpark/"]],
         ["hello_world"])

--- a/test/test_functions.py
+++ b/test/test_functions.py
@@ -2,7 +2,7 @@
 Tests for the functions module.
 """
 
-from src.functions import combine
+from functions import combine
 
 def test_combine():
     expected = "hello world"


### PR DESCRIPTION
Solves #9 
The PYTHONPATH variable can be adjusted so there is more flexibility on the code location.
In this template we have the code under "src", .env files can be used to adjust this and other environment variables.


